### PR TITLE
ci: adds slither analysis

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,53 @@
+name: Slither Analysis
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out github repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Hardhat compile
+        run: yarn compile
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.1.1
+        id: slither
+        continue-on-error: true
+        with:
+          solc-version: 0.8.13
+          ignore-compile: true
+          node-version: 16
+          sarif: results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,4 @@
+{
+  "detectors_to_exclude": "conformance-to-solidity-naming-conventions",
+  "filter_paths": "node_modules|openzeppelin|mocks"
+}

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
-  "detectors_to_exclude": "conformance-to-solidity-naming-conventions",
+  "detectors_to_exclude": "incorrect-versions-of-solidity,conformance-to-solidity-naming-conventions",
   "filter_paths": "node_modules|openzeppelin|mocks"
 }


### PR DESCRIPTION
Adds [Slither](https://github.com/crytic/slither) analysis to the repository. Although this has already been deployed, it adds to the quality of the repository.

Also: I'm trying to add it to `v2-core` and `v2-periphery` and have encountered tons of errors. I needed to success in at least one repo. I need my dopamine hit 🤐 .