### PR TITLE
feat: add more view functions

### DIFF
--- a/contracts/ChainlinkRegistry/ChainlinkRegistry.sol
+++ b/contracts/ChainlinkRegistry/ChainlinkRegistry.sol
@@ -89,6 +89,52 @@ contract ChainlinkRegistry is AccessControl, CollectableDust, IChainlinkRegistry
     return _getAssignedFeedOrFail(_base, _quote).latestRoundData();
   }
 
+  function getRoundData(
+    address _base,
+    address _quote,
+    uint80 _roundId
+  )
+    external
+    view
+    returns (
+      uint80,
+      int256,
+      uint256,
+      uint256,
+      uint80
+    )
+  {
+    return _getAssignedFeedOrFail(_base, _quote).getRoundData(_roundId);
+  }
+
+  function latestAnswer(address _base, address _quote) external view returns (int256) {
+    return _getAssignedFeedOrFail(_base, _quote).latestAnswer();
+  }
+
+  function latestTimestamp(address _base, address _quote) external view returns (uint256) {
+    return _getAssignedFeedOrFail(_base, _quote).latestTimestamp();
+  }
+
+  function latestRound(address _base, address _quote) external view returns (uint256) {
+    return _getAssignedFeedOrFail(_base, _quote).latestRound();
+  }
+
+  function getAnswer(
+    address _base,
+    address _quote,
+    uint256 _roundId
+  ) external view returns (int256) {
+    return _getAssignedFeedOrFail(_base, _quote).getAnswer(_roundId);
+  }
+
+  function getTimestamp(
+    address _base,
+    address _quote,
+    uint256 _roundId
+  ) external view returns (uint256) {
+    return _getAssignedFeedOrFail(_base, _quote).getTimestamp(_roundId);
+  }
+
   function _getKey(address _base, address _quote) internal pure returns (bytes32) {
     return keccak256(abi.encodePacked(_base, _quote));
   }

--- a/test/integration/ChainlinkRegistry/chainlink-registry.spec.ts
+++ b/test/integration/ChainlinkRegistry/chainlink-registry.spec.ts
@@ -8,7 +8,6 @@ import { given, then, when } from '@test-utils/bdd';
 import { expect } from 'chai';
 import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory/typechained';
 
-type Keys = keyof AggregatorV2V3Interface['functions'] & keyof ChainlinkRegistry['functions'];
 type Token = { address: string; name: string };
 
 const LINK = { address: '0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39', name: 'LINK' };
@@ -25,7 +24,9 @@ const PAIRS = [
   { base: LINK, quote: ETH, feed: '0xb77fa460604b9C6435A235D057F7D319AC83cb53' },
 ];
 
-const REDIRECT_FUNCTIONS: Keys[] = ['decimals', 'description', 'version', 'latestRoundData'];
+// We are not testing every function, since we are already doing this in the unit tests
+const REDIRECT_FUNCTIONS = ['decimals', 'description', 'version', 'latestRoundData', 'latestAnswer', 'latestRound'] as const;
+type Functions = typeof REDIRECT_FUNCTIONS[number];
 
 describe('ChainlinkRegistry', () => {
   let admin: JsonRpcSigner;
@@ -55,7 +56,7 @@ describe('ChainlinkRegistry', () => {
     snapshotId = await snapshot.take();
   });
 
-  beforeEach('Deploy and configure', async () => {
+  beforeEach(async () => {
     await snapshot.revert(snapshotId);
   });
 
@@ -83,7 +84,7 @@ describe('ChainlinkRegistry', () => {
     quote,
     feed,
   }: {
-    method: Keys;
+    method: Functions;
     base: Token;
     quote: Token;
     feed: () => AggregatorV2V3Interface;

--- a/test/integration/ChainlinkRegistry/chainlink-registry.spec.ts
+++ b/test/integration/ChainlinkRegistry/chainlink-registry.spec.ts
@@ -3,7 +3,7 @@ import { JsonRpcSigner } from '@ethersproject/providers';
 import { wallet } from '@test-utils';
 import evm, { snapshot } from '@test-utils/evm';
 import { AggregatorV2V3Interface, ChainlinkRegistry } from '@typechained';
-import FEED_ABI from '@chainlink/contracts/abi/v0.8/AggregatorV3Interface.json';
+import FEED_ABI from '@chainlink/contracts/abi/v0.8/AggregatorV2V3Interface.json';
 import { given, then, when } from '@test-utils/bdd';
 import { expect } from 'chai';
 import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory/typechained';


### PR DESCRIPTION
We realized that we weren't implementing Chainlink's `FeedRegistryInterface` interface completely, so we will change it, Pr by PR

We are starting with adding support for more proxy view functions