### PR TITLE
feat: add non supported functions

### DIFF
--- a/contracts/ChainlinkRegistry/ChainlinkRegistry.sol
+++ b/contracts/ChainlinkRegistry/ChainlinkRegistry.sol
@@ -59,22 +59,22 @@ contract ChainlinkRegistry is AccessControl, CollectableDust, IChainlinkRegistry
     }
   }
 
-  /// @inheritdoc IFeedRegistry
+  /// @inheritdoc FeedRegistryInterface
   function decimals(address _base, address _quote) external view returns (uint8) {
     return _getAssignedFeedOrFail(_base, _quote).decimals();
   }
 
-  /// @inheritdoc IFeedRegistry
+  /// @inheritdoc FeedRegistryInterface
   function description(address _base, address _quote) external view returns (string memory) {
     return _getAssignedFeedOrFail(_base, _quote).description();
   }
 
-  /// @inheritdoc IFeedRegistry
+  /// @inheritdoc FeedRegistryInterface
   function version(address _base, address _quote) external view returns (uint256) {
     return _getAssignedFeedOrFail(_base, _quote).version();
   }
 
-  /// @inheritdoc IFeedRegistry
+  /// @inheritdoc FeedRegistryInterface
   function latestRoundData(address _base, address _quote)
     external
     view
@@ -89,6 +89,7 @@ contract ChainlinkRegistry is AccessControl, CollectableDust, IChainlinkRegistry
     return _getAssignedFeedOrFail(_base, _quote).latestRoundData();
   }
 
+  /// @inheritdoc FeedRegistryInterface
   function getRoundData(
     address _base,
     address _quote,
@@ -107,18 +108,22 @@ contract ChainlinkRegistry is AccessControl, CollectableDust, IChainlinkRegistry
     return _getAssignedFeedOrFail(_base, _quote).getRoundData(_roundId);
   }
 
+  /// @inheritdoc FeedRegistryInterface
   function latestAnswer(address _base, address _quote) external view returns (int256) {
     return _getAssignedFeedOrFail(_base, _quote).latestAnswer();
   }
 
+  /// @inheritdoc FeedRegistryInterface
   function latestTimestamp(address _base, address _quote) external view returns (uint256) {
     return _getAssignedFeedOrFail(_base, _quote).latestTimestamp();
   }
 
+  /// @inheritdoc FeedRegistryInterface
   function latestRound(address _base, address _quote) external view returns (uint256) {
     return _getAssignedFeedOrFail(_base, _quote).latestRound();
   }
 
+  /// @inheritdoc FeedRegistryInterface
   function getAnswer(
     address _base,
     address _quote,
@@ -135,8 +140,138 @@ contract ChainlinkRegistry is AccessControl, CollectableDust, IChainlinkRegistry
     return _getAssignedFeedOrFail(_base, _quote).getTimestamp(_roundId);
   }
 
+  /// @inheritdoc FeedRegistryInterface
+  function getFeed(address _base, address _quote) external view returns (AggregatorV2V3Interface) {
+    // TODO: Implement
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getPhaseFeed(
+    address,
+    address,
+    uint16
+  ) external pure returns (AggregatorV2V3Interface) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function isFeedEnabled(address) external pure returns (bool) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getPhase(
+    address,
+    address,
+    uint16
+  ) external pure returns (Phase memory) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getRoundFeed(
+    address,
+    address,
+    uint80
+  ) external pure returns (AggregatorV2V3Interface) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getPhaseRange(
+    address,
+    address,
+    uint16
+  ) external pure returns (uint80, uint80) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getPreviousRoundId(
+    address,
+    address,
+    uint80
+  ) external pure returns (uint80) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getNextRoundId(
+    address,
+    address,
+    uint80
+  ) external pure returns (uint80) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function proposeFeed(
+    address,
+    address,
+    address
+  ) external pure {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function confirmFeed(
+    address,
+    address,
+    address
+  ) external pure {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getProposedFeed(address, address) external pure returns (AggregatorV2V3Interface) {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function proposedGetRoundData(
+    address,
+    address,
+    uint80
+  )
+    external
+    pure
+    returns (
+      uint80,
+      int256,
+      uint256,
+      uint256,
+      uint80
+    )
+  {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function proposedLatestRoundData(address, address)
+    external
+    pure
+    returns (
+      uint80,
+      int256,
+      uint256,
+      uint256,
+      uint80
+    )
+  {
+    _throwNotSupported();
+  }
+
+  /// @inheritdoc FeedRegistryInterface
+  function getCurrentPhaseId(address, address) external pure returns (uint16) {
+    _throwNotSupported();
+  }
+
   function _getKey(address _base, address _quote) internal pure returns (bytes32) {
     return keccak256(abi.encodePacked(_base, _quote));
+  }
+
+  function _throwNotSupported() internal pure {
+    revert FunctionNotSupported();
   }
 }
 

--- a/contracts/interfaces/IChainlinkRegistry.sol
+++ b/contracts/interfaces/IChainlinkRegistry.sol
@@ -1,53 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
-import '@chainlink/contracts/src/v0.8/interfaces/AggregatorV2V3Interface.sol';
+import '@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol';
 import './utils/ICollectableDust.sol';
 
-interface IFeedRegistry {
-  /// @notice Returns the number of decimals present in the response value.
-  /// @dev Will revert with `FeedNotFound` if no feed is found for the given base and quote
-  /// @param _base The base asset address
-  /// @param _quote The quote asset address
-  /// @return The number of decimals in the response
-  function decimals(address _base, address _quote) external view returns (uint8);
-
-  /// @notice Returns the description of the underlying aggregator that the proxy points to.
-  /// @dev Will revert with `FeedNotFound` if no feed is found for the given base and quote
-  /// @param _base The base asset address
-  /// @param _quote The quote asset address
-  /// @return The description of the underlying aggregator
-  function description(address _base, address _quote) external view returns (string memory);
-
-  /// @notice Returns the version representing the type of aggregator the proxy points to.
-  /// @dev Will revert with `FeedNotFound` if no feed is found for the given base and quote
-  /// @param _base The base asset address
-  /// @param _quote The quote asset address
-  /// @return The version of the type of aggregator
-  function version(address _base, address _quote) external view returns (uint256);
-
-  /// @notice Returns the version representing the type of aggregator the proxy points to.
-  /// @dev Will revert with `FeedNotFound` if no feed is found for the given base and quote
-  /// @param _base The base asset address
-  /// @param _quote The quote asset address
-  /// @return _roundId The round ID
-  /// @return _answer The price
-  /// @return _startedAt Timestamp of when the round started
-  /// @return _updatedAt Timestamp of when the round was updated
-  /// @return _answeredInRound The round ID of the round in which the answer was computed
-  function latestRoundData(address _base, address _quote)
-    external
-    view
-    returns (
-      uint80 _roundId,
-      int256 _answer,
-      uint256 _startedAt,
-      uint256 _updatedAt,
-      uint80 _answeredInRound
-    );
-}
-
-interface IChainlinkRegistry is IFeedRegistry, ICollectableDust {
+interface IChainlinkRegistry is FeedRegistryInterface, ICollectableDust {
   /// @notice A Chainlink feed
   struct Feed {
     address base;
@@ -68,6 +25,14 @@ interface IChainlinkRegistry is IFeedRegistry, ICollectableDust {
 
   /// @notice Thrown when one of the parameters is a zero address
   error ZeroAddress();
+
+  /**
+   * @notice Thrown when a function that is not supported is called
+   *         We want to implement Chainlink's feed registry interface completely, but some of the functions
+   *         don't make sense in our context. Specially those meant for management. So we will implement
+   *         those functions, but we will revert when they are called
+   */
+  error FunctionNotSupported();
 
   /**
    * @notice Emitted when fees are modified

--- a/test/unit/ChainlinkRegistry/chainlink-registry.spec.ts
+++ b/test/unit/ChainlinkRegistry/chainlink-registry.spec.ts
@@ -207,6 +207,71 @@ contract('ChainlinkRegistry', () => {
     returnsWhenMocked: BigNumber.from(50),
   });
 
+  notSupportedTest({
+    method: 'getPhaseFeed',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'isFeedEnabled',
+    args: () => [constants.NOT_ZERO_ADDRESS],
+  });
+
+  notSupportedTest({
+    method: 'getPhase',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'getRoundFeed',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'getPhaseRange',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'getPreviousRoundId',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'getNextRoundId',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'proposeFeed',
+    args: () => [LINK, USD, constants.NOT_ZERO_ADDRESS],
+  });
+
+  notSupportedTest({
+    method: 'confirmFeed',
+    args: () => [LINK, USD, constants.NOT_ZERO_ADDRESS],
+  });
+
+  notSupportedTest({
+    method: 'getProposedFeed',
+    args: () => [LINK, USD],
+  });
+
+  notSupportedTest({
+    method: 'proposedGetRoundData',
+    args: () => [LINK, USD, 1234],
+  });
+
+  notSupportedTest({
+    method: 'proposedLatestRoundData',
+    args: () => [LINK, USD],
+  });
+
+  notSupportedTest({
+    method: 'getCurrentPhaseId',
+    args: () => [LINK, USD],
+  });
+
   /**
    * This test makes sure that when a method is called and the feed is not set, then the call reverts.
    * However, when the method is called and there is a feed set, then the return value is just redirected
@@ -250,6 +315,26 @@ contract('ChainlinkRegistry', () => {
         });
         then('return value from feed is returned through registry', async () => {
           expect(result).to.eql(returnValue);
+        });
+      });
+    });
+  }
+  function notSupportedTest<Key extends keyof ChainlinkRegistry['functions'] & string>({
+    method,
+    args,
+  }: {
+    method: Key;
+    args: () => Parameters<ChainlinkRegistry['functions'][Key]>;
+  }) {
+    describe(method, () => {
+      when(`calling ${method} is called`, () => {
+        then('reverts with message', async () => {
+          await behaviours.txShouldRevertWithMessage({
+            contract: registry,
+            func: method,
+            args: args(),
+            message: 'FunctionNotSupported',
+          });
         });
       });
     });


### PR DESCRIPTION
We are now implementing the whole `FeedRegistryInterface` interface, but we are reverting in the functions that are not supported 