### PR TITLE
fix: use chainlinks registry in ethereum

### DIFF
--- a/deploy/001_registry.ts
+++ b/deploy/001_registry.ts
@@ -1,26 +1,35 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from '@0xged/hardhat-deploy/types';
 import { bytecode } from '../artifacts/contracts/ChainlinkRegistry/ChainlinkRegistry.sol/ChainlinkRegistry.json';
+import { abi as FeedRegistryAbi } from '../artifacts/@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol/FeedRegistryInterface.json';
 import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, msig } = await hre.getNamedAccounts();
 
-  await deployThroughDeterministicFactory({
-    deployer,
-    name: 'ChainlinkFeedRegistry',
-    salt: 'MF-Chainlink-Feed-Registry-V1',
-    contract: 'contracts/ChainlinkRegistry/ChainlinkRegistry.sol:ChainlinkRegistry',
-    bytecode,
-    constructorArgs: {
-      types: ['address', 'address[]'],
-      values: [msig, [msig]],
-    },
-    log: !process.env.TEST,
-    overrides: {
-      gasLimit: 3_000_000,
-    },
-  });
+  if (hre.deployments.getNetworkName() === 'ethereum') {
+    // We will use the one operated by chainlink
+    await hre.deployments.save('ChainlinkFeedRegistry', {
+      abi: FeedRegistryAbi,
+      address: '0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf',
+    });
+  } else {
+    await deployThroughDeterministicFactory({
+      deployer,
+      name: 'ChainlinkFeedRegistry',
+      salt: 'MF-Chainlink-Feed-Registry-V1',
+      contract: 'contracts/ChainlinkRegistry/ChainlinkRegistry.sol:ChainlinkRegistry',
+      bytecode,
+      constructorArgs: {
+        types: ['address', 'address[]'],
+        values: [msig, [msig]],
+      },
+      log: !process.env.TEST,
+      overrides: {
+        gasLimit: 3_000_000,
+      },
+    });
+  }
 };
 
 deployFunction.tags = ['ChainlinkFeedRegistry'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mean-finance/chainlink-registry",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0-rc4",
   "description": "A Chainlink Feed Registry by mean.finance",
   "keywords": [
     "ethereum",
@@ -24,6 +24,8 @@
     "contracts/interfaces",
     "artifacts/contracts/interfaces/**/*.json",
     "artifacts/contracts/ChainlinkRegistry/**/*.json",
+    "artifacts/@chainlink/**/*.json",
+    "!artifacts/@chainlink/**/*.dbg.json",
     "!artifacts/contracts/**/**/*.dbg.json",
     "typechained",
     "!typechained/**/*Mock*",


### PR DESCRIPTION
I made a mistake in #13. Before that change, we would use Chainlink's official feed registry in ethereum. We should continue to do so